### PR TITLE
Disable TLS tickets by default

### DIFF
--- a/ssl-config-generator/index.html
+++ b/ssl-config-generator/index.html
@@ -54,6 +54,7 @@ server {
     ssl_certificate_key /path/to/private_key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
 {{dhparam}}
 
     # {{securityProfile}} configuration. tweak to your needs.
@@ -85,6 +86,7 @@ server {
     SSLProtocol             {{sslProtocols}}
     SSLCipherSuite          {{cipherSuites}}
     SSLHonorCipherOrder     on
+    SSLSessionTickets       off
 {{compression}}
 {{ocspStapling}}
 {{hsts}}
@@ -103,7 +105,8 @@ global
     # set default parameters to the {{securityProfile}} configuration
     tune.ssl.default-dh-param {{maxDHKeySize}}
     ssl-default-bind-ciphers {{cipherSuites}}
-
+    ssl-default-bind-options no-tls-tickets
+    
 frontend ft_test
     mode    http
     bind    0.0.0.0:443 {{sslProtocols}} crt /path/to/&lt;cert+privkey+intermediate+dhparam&gt;


### PR DESCRIPTION
By default, all servers enable TLS tickets. However, the keys are only renewed on server restart, leasing to the unfortunate situation that the secret key for the tickets doesn't change for a long time which effectively destroys the perfect-forward-secrecy guarantee. While all servers allow to specify a file which contains the key on disk, it is generally recommended to not use this as this allows the key to leak under effectively the same situations the private key could leak, which again defeats the purpose of PFS.

The use of server-stored sessions (identified by session ids) is not affected by this and is always safe.

Because of this, The Document™ specifies at https://wiki.mozilla.org/Security/Server_Side_TLS#TLS_tickets_.28RFC_5077.29 that support for TLS tickets should be disabled if possible. This patch adds the relevant config options.

Note that Apache only supports this setting since 2.2.30 when used with OpenSSL >= 0.9.8f - http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#sslsessiontickets

Some versions of HAProxy (i.e >= 1.6-dev2) allow to set the key via the stats socket. This however requires custom scripts and good maintenance on the side of the operator. A safe default in any case is to disable session tickets.
